### PR TITLE
Temperature conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ We highly encourage you to use CocoaPods for installation so you're always up to
 
 ## Usage
 
-To get started you need to register a delegate so your application can ``start`` and``stop`` the measurements and get temperature readings from the device. Your delegate must implement the ``THMThermodoDelegate`` protocol. 
+To get started you need to register a delegate so your application can ``start`` and``stop`` the measurements and get temperature readings from the device. Your delegate must implement the ``THMThermodoDelegate`` protocol.
 
 ```objectivec
 @protocol THMThermodoDelegate <NSObject>
@@ -60,7 +60,7 @@ To get started you need to register a delegate so your application can ``start``
 /*!
  * This method will be called every time the Thermodo device returns a new temperature reading.
  * @param thermodo The shared THMThermodo instance
- * @param temperature The measured temperature in celcius
+ * @param temperature The measured temperature in celsius
  */
 - (void)thermodo:(THMThermodo *)thermodo didGetTemperature:(CGFloat)temperature;
 
@@ -104,7 +104,7 @@ No. In order to get device readings and any kind of reponse from SDK you must ha
 ### The readings from the device are too hot
 
 We have used a lot of time on making sure that Thermodo delivers accurate and consistent temperature readings. Unfortunately this precision also means that the Thermodo
-sensor is easily affected by heat from your device (your iPhone / iPad / Macbook) or just the palm of your hand. To get the most accurate readings we recommend using an extension cord. For more 
+sensor is easily affected by heat from your device (your iPhone / iPad / Macbook) or just the palm of your hand. To get the most accurate readings we recommend using an extension cord. For more
 information [this video update from the Kickstarter project](http://vimeo.com/76458958).
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -104,8 +104,7 @@ No. In order to get device readings and any kind of reponse from SDK you must ha
 ### The readings from the device are too hot
 
 We have used a lot of time on making sure that Thermodo delivers accurate and consistent temperature readings. Unfortunately this precision also means that the Thermodo
-sensor is easily affected by heat from your device (your iPhone / iPad / Macbook) or just the palm of your hand. To get the most accurate readings we recommend using an extension cord. For more
-information [this video update from the Kickstarter project](http://vimeo.com/76458958).
+sensor is easily affected by heat from your device (your iPhone / iPad / Macbook) or just the palm of your hand. To get the most accurate readings we recommend using an extension cord. For more information [this video update from the Kickstarter project](http://vimeo.com/76458958).
 
 ## Contributing
 

--- a/ThermodoSDK/THMThermodo+Conversion.h
+++ b/ThermodoSDK/THMThermodo+Conversion.h
@@ -1,0 +1,26 @@
+//
+//  THMThermodo+Conversion.h
+//  ThermodoSDK
+//
+//  Copyright (c) 2013 Robocat (http://robocatapps.com)
+//  All rights reserved.
+
+// Enumeration of available temperature scales
+typedef NS_ENUM(NSInteger, THMThermodoTemperature) {
+    THMThermodoCelsius = 0,
+    THMThermodoFahrenheit,
+    THMThermodoKelvin,
+    THMThermodoRankine,
+};
+
+@interface THMThermodo (Conversion)
+
+/*!
+ * Convert the base temperature to another scale.
+ * @param temperature The base temperature returned by Thermodo
+ * @param unit Target unit from THMThermodoTemperature enumeration
+ * @return Converted temperature
+ */
+- (CGFloat)convertTemperature:(CGFloat)temperature toUnit:(THMThermodoTemperature)unit;
+
+@end

--- a/ThermodoSDK/THMThermodo+Conversion.m
+++ b/ThermodoSDK/THMThermodo+Conversion.m
@@ -1,0 +1,34 @@
+//
+//  THMThermodo+Conversion.m
+//  ThermodoSDK
+//
+//  Copyright (c) 2013 Robocat (http://robocatapps.com)
+//  All rights reserved.
+
+#import "THMThermodo+Conversion.h"
+
+@implementation THMThermodo (Conversion)
+
+- (CGFloat)converTemperature:(CGFloat)temperature toUnit:(THMThermodoTemperature)unit {
+    CGFloat convertedTemperature;
+    
+    switch (unit) {
+        case THMThermodoFahrenheit:
+            convertedTemperature = (temperature * (9.0f / 5.0f)) + 32.0f;
+            break;
+        case THMThermodoKelvin:
+            convertedTemperature = temperature + 273.15f;
+            break;
+        case THMThermodoRankine:
+            convertedTemperature = (temperature + 273.15f) * (9.0f / 5.0f);
+            break;
+        default:
+            // All unknown units + celsius
+            convertedTemperature = temperature;
+            break;
+    }
+    
+    return convertedTemperature;
+}
+
+@end


### PR DESCRIPTION
Ideally unit conversion would be included in `THMThermodo`, but can be separated away into a more UI facing category. The goal is to offer the readings in a multitude of scales, which would allow displaying data based on either user preference or user locale, without forcing the 3rd party developer to include their own conversion logic (meaning adding units and/or changing internal logic to reach those units is transparent for the developer).

In addition, some tidying up in the `README.md` to fix a few oddities.
